### PR TITLE
More convenient way to allocate new blocks without affecting performance

### DIFF
--- a/MemoryPool.h
+++ b/MemoryPool.h
@@ -43,7 +43,7 @@ namespace CPPShift::Memory {
 		 * 
 		 * @returns SMemoryBlockHeader* Pointer to the header of the memory block
 		 */
-		static SMemoryBlockHeader* createMemoryBlock(size_t block_size = MEMORYPOOL_DEFAULT_BLOCK_SIZE);
+		static void createMemoryBlock(MemoryPool*  mp, size_t block_size = MEMORYPOOL_DEFAULT_BLOCK_SIZE);
 
 		/**
 		 * Allocates memory in a pool


### PR DESCRIPTION
Modified the `CPPShift::Memory::MemoryPoolManager::createMemoryBlock` function to retrieve a memory pool structure (MemoryPool*) & a size, the function then assigns the block to the pool block chain for you - before it just created the block and let you do the work of chaining it together to the pool, no affect in performance (even a bit faster but negligible).